### PR TITLE
the curly braces caused a warning

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,4 +23,4 @@
 
 - name: NPM Install global packages
   npm: name={{item}} global=yes
-  with_items: "{{nodejs_global_packages}}"
+  with_items: nodejs_global_packages


### PR DESCRIPTION
With the curly braces I received a warning (in Ansible 1.4.4):

```
[WARNING]: It is unneccessary to use '{{' in loops, leave variables in loop
expressions bare.
```

This change gets rid of the warning.
