### PR TITLE
Add integration tests. No vagrantfile, pushed to galaxy role. TestKitche...

### DIFF
--- a/tests/integration-tests.yml
+++ b/tests/integration-tests.yml
@@ -1,0 +1,13 @@
+---
+#
+# integration-tests.yml
+#
+
+- hosts: all
+  sudo: True
+  tasks:
+    # Tests
+    - name: Check node
+      command: which node
+      register: node_path
+    - debug: msg="All Tests passed!"


### PR DESCRIPTION
Add integration tests. No vagrantfile, pushed to galaxy role. TestKitchen like functionality is required for individual role testing. This pull should still address testing, while not in a proper manner as it can be done with chef.
