### PR TITLE
Alternative tmp directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,15 +9,15 @@
   changed_when: "wanted_version_installed.rc == 1"
 
 - name: Download nodejs {{nodejs_version_tag}}
-  get_url: url={{nodejs_base_url}} dest={{tmp_dir}}{{nodejs_file_name}}
+  get_url: url={{nodejs_base_url}} dest={{nodejs_tmp_dir}}{{nodejs_file_name}}
   when: wanted_version_installed.rc == 1
 
 - name: Unpack nodejs {{nodejs_version_tag}}
-  command: tar -xvzf {{nodejs_file_name}} chdir={{tmp_dir}}
+  command: tar -xvzf {{nodejs_file_name}} chdir={{nodejs_tmp_dir}}
   when: wanted_version_installed.rc == 1
 
 - name: Compile and install nodejs {{nodejs_version_tag}}
-  shell: ./configure --prefix={{nodejs_path}} && make && make install chdir={{tmp_dir}}{{nodejs_file_tag}}
+  shell: ./configure --prefix={{nodejs_path}} && make && make install chdir={{nodejs_tmp_dir}}{{nodejs_file_tag}}
   sudo: true
   when: wanted_version_installed.rc == 1
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,7 +6,7 @@ nodejs_file_tag: "node-{{nodejs_version_tag}}"
 nodejs_file_name: "{{nodejs_file_tag}}.tar.gz"
 nodejs_base_url: "http://nodejs.org/dist/v{{nodejs_version}}/{{nodejs_file_name}}"
 nodejs_path: "/usr/local/"
-tmp_dir: "/tmp/"
+nodejs_tmp_dir: "/tmp/"
 nodejs_global_packages:
   - nodemon
   - debug


### PR DESCRIPTION
I made these changes because my CentOS box on Rackspace has the `noexec` option specified for `/tmp`, which causes a "Permission denied" error when running `./configure`. Even when I tried changing that to `python configure`, I still get permission denied during make when it tries to run `mksnapshot`. My solution to the problem is to use a variable to specify which directory to make nodejs inside of. That way I can override the directory with a directory in the user's home or something.
@JasonGiedymin I tried modifying the ansible-galaxy-roles playbook to remount tmp with noexec in order to reproduce the problem but I was unsuccessful :frowning: 
