### PR TITLE
soft-code nodjes_path in integration test

### DIFF
--- a/tests/integration-tests.yml
+++ b/tests/integration-tests.yml
@@ -12,4 +12,4 @@
       register: node_path
     - debug: msg="Node was installed in {{node_path.stdout}}"
     - fail: msg="Node Not Found, tests failed."
-      when: node_path.stdout != "/usr/local/bin/node"
+      when: node_path.stdout != "{{nodejs_path}}bin/node"


### PR DESCRIPTION
As it stands, the tests don't pass when run from ansible-galaxy-roles. I think the solution is to softcode the nodejs path.
