### PR TITLE
increase get_url timeout in 1.8

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Ansible NodeJS Playbook Role
   company: http://jasongiedymin.com
   license: Apache 2
-  min_ansible_version: 1.3
+  min_ansible_version: 1.8
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   changed_when: "wanted_version_installed.rc == 1"
 
 - name: Download nodejs {{nodejs_version_tag}}
-  get_url: url={{nodejs_tarball_url}} dest={{nodejs_tmp_dir}}{{nodejs_file_name}}
+  get_url: url={{nodejs_tarball_url}} dest={{nodejs_tmp_dir}}{{nodejs_file_name}} timeout=120
   when: wanted_version_installed.rc == 1
 
 - name: Verify SHASUM of nodejs {{nodejs_version_tag}}


### PR DESCRIPTION
This increases the timeout for downloading the tarball in Ansible 1.8+. The default is 10 seconds. The file is pretty big and even on my decent connection it took 56 seconds, so I'm proposing to set it at 120 seconds for good measure. Unfortunately, since this parameter was introduced in 1.8, this means the minimum ansible version for this role has to be increased to 1.8.