### PR TITLE
move overridable vars to defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+nodejs_version: "0.10.36"
+nodejs_path: "/usr/local/"
+nodejs_tmp_dir: "/tmp/"
+nodejs_global_packages:
+  - nodemon
+  - debug
+  - foreman

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,15 +1,8 @@
 ---
 nodejs_playbook_version: "0.1.5"
-nodejs_version: "0.10.36"
 nodejs_version_tag: "v{{nodejs_version}}"
 nodejs_file_tag: "node-{{nodejs_version_tag}}"
 nodejs_file_name: "{{nodejs_file_tag}}.tar.gz"
 nodejs_base_url: "http://nodejs.org/dist/v{{nodejs_version}}/"
 nodejs_tarball_url: "{{nodejs_base_url}}{{nodejs_file_name}}"
 nodejs_shasum_url: "{{nodejs_base_url}}SHASUMS.txt"
-nodejs_path: "/usr/local/"
-nodejs_tmp_dir: "/tmp/"
-nodejs_global_packages:
-  - nodemon
-  - debug
-  - foreman


### PR DESCRIPTION
Hi Jason,
I requested something similar to this earlier in https://github.com/AnsibleShipyard/ansible-nodejs/pull/2.
The solution you recommended worked well then, but it's not working for me anymore. Maybe the variable precedence changed? Regardless, if I'm reading the docs correctly, overridable variables belong in `defaults` so that's what this PR does.

http://docs.ansible.com/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable

With this changes I am again able to override these variables. What do you think?