### PR TITLE
add explicit designating PATH for CentOS6

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,12 @@
   sudo: true
   when: wanted_version_installed.rc == 1
 
+- name: Register remote PATH File
+  shell: "echo $PATH"
+  register: nodejs_path_out
+
 - name: NPM Install global packages
   npm: name={{item}} global=yes
   with_items: nodejs_global_packages
+  environment:
+    PATH: "{{ nodejs_path }}/bin:{{ nodejs_path_out.stdout }}"


### PR DESCRIPTION
This modification is required for CentOS because `nodejs` binary files are installed at `{{ nodejs_path }}/bin`.