### PR TITLE
JasonGiedymin.nodejs: Fix SHASUM check to work for newer node.js releases which use sha256sum

### DIFF
--- a/tasks/install_from_source.yml
+++ b/tasks/install_from_source.yml
@@ -16,7 +16,11 @@
 
 - name: Verify SHASUM of nodejs {{nodejs_version_tag}}
   shell: curl {{nodejs_shasum_url}} | grep {{nodejs_file_name}} | sha1sum -c chdir={{nodejs_tmp_dir}}
-  when: wanted_version_installed.rc == 1
+  when: wanted_version_installed.rc == 1 and 'SHASUMS256' not in nodejs_shasum_url
+
+- name: Verify SHA256SUM of nodejs {{nodejs_version_tag}}
+  shell: curl {{nodejs_shasum_url}} | grep {{nodejs_file_name}} | sha256sum -c chdir={{nodejs_tmp_dir}}
+  when: wanted_version_installed.rc == 1 and 'SHASUMS256' in nodejs_shasum_url
 
 - name: Unpack nodejs {{nodejs_version_tag}}
   command: tar -xvzf {{nodejs_file_name}} chdir={{nodejs_tmp_dir}}


### PR DESCRIPTION
To test, set vars `nodejs_version` and `nodejs_shasum_url` in playbook like this:

```
- name: Install Node.js
  hosts: localhost
  gather_facts: yes
  sudo: yes
  vars:
    nodejs_version: 4.0.0
    nodejs_shasum_url: http://nodejs.org/dist/v4.0.0/SHASUMS256.txt
  pre_tasks:
    - name: update packages
      yum: >
         name=*
         state=latest

    - name: install specific packages
      yum: name={{ item }} state=latest
      with_items:
        - wget
        - gcc
        - make
        - gcc-c++
        - vim
        - mlocate
        - mc
        - lsof
        - psmisc
        - bind-utils
        - epel-release
        - nc
        - git

    - name: install epel specific packages
      yum: name={{ item }} state=latest
      with_items:
        - nrpe
        - nagios-plugins-nrpe
        - unbound
        - liblockfile
        - lockfile-progs
        - perl-IPC-Signal
        - perl-Proc-WaitStat
        - perl-mime-construct
  roles:
    - JasonGiedymin.nodejs
```