### PR TITLE
make shasum command configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,6 @@ nodejs_file_tag: "node-{{nodejs_version_tag}}"
 nodejs_file_name: "{{nodejs_file_tag}}.tar.gz"
 nodejs_base_url: "http://nodejs.org/dist/v{{nodejs_version}}/"
 nodejs_tarball_url: "{{nodejs_base_url}}{{nodejs_file_name}}"
-nodejs_shasum_file: "{{(nodejs_version | version_compare('1.0.0', '>=') | ternary('SHASUMS256.txt', 'SHASUMS.txt')}}"
-nodejs_shasum_url: {{nodejs_base_url}}{{nodejs_shasum_file}}
-nodejs_shasum_exec: {{"(nodejs_version | version_compare('1.0.0', '>=') | ternary('sha256', 'sha1')"}}
+nodejs_shasum_file: "{{(nodejs_version | version_compare('1.0.0', '>=')) | ternary('SHASUMS256.txt', 'SHASUMS.txt')}}"
+nodejs_shasum_url: "{{nodejs_base_url}}{{nodejs_shasum_file}}"
+nodejs_shasum_exec: "{{(nodejs_version | version_compare('1.0.0', '>=')) | ternary('sha256', 'sha1')}}sum"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,4 +13,6 @@ nodejs_file_tag: "node-{{nodejs_version_tag}}"
 nodejs_file_name: "{{nodejs_file_tag}}.tar.gz"
 nodejs_base_url: "http://nodejs.org/dist/v{{nodejs_version}}/"
 nodejs_tarball_url: "{{nodejs_base_url}}{{nodejs_file_name}}"
-nodejs_shasum_url: "{{nodejs_base_url}}SHASUMS.txt"
+nodejs_shasum_file: "{{(nodejs_version | version_compare('1.0.0', '>=') | ternary('SHASUMS256.txt', 'SHASUMS.txt')}}"
+nodejs_shasum_url: {{nodejs_base_url}}{{nodejs_shasum_file}}
+nodejs_shasum_exec: {{"(nodejs_version | version_compare('1.0.0', '>=') | ternary('sha256', 'sha1')"}}

--- a/tasks/install_from_source.yml
+++ b/tasks/install_from_source.yml
@@ -15,7 +15,7 @@
   when: wanted_version_installed.rc == 1
 
 - name: Verify SHASUM of nodejs {{nodejs_version_tag}}
-  shell: curl {{nodejs_shasum_url}} | grep {{nodejs_file_name}} | sha1sum -c chdir={{nodejs_tmp_dir}}
+  shell: curl {{nodejs_shasum_url}} | grep {{nodejs_file_name}} | {{nodejs_shasum_exec}} -c chdir={{nodejs_tmp_dir}}
   when: wanted_version_installed.rc == 1
 
 - name: Unpack nodejs {{nodejs_version_tag}}


### PR DESCRIPTION
reason being that later versions of node use sha256 instead of sha1.