### PR TITLE
render nodejs_global_packages var

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,6 @@
 
 - name: NPM Install global packages
   npm: name={{item}} global=yes
-  with_items: nodejs_global_packages
+  with_items: "{{ nodejs_global_packages }}"
   environment:
     PATH: "{{ nodejs_path }}/bin:{{ nodejs_path_out.stdout }}"


### PR DESCRIPTION
@AnsibleShipyard/developers My team is updating to Ansible 2 and we ran into an issue with this task where `nodejs_global_packages` was getting interpreted literally:

>TASK [galaxy/JasonGiedymin.nodejs : NPM Install global packages] ***************
>failed: [vagrant_web1] (item=nodejs_global_packages) => {"cmd": "/usr//bin/npm install --global nodejs_global_packages", "failed": true, "item": "nodejs_global_packages", "msg": "npm ERR! 404 Not Found\nnpm ERR! 404 \nnpm ERR! 404 'nodejs_global_packages' is not in the npm registry.\nnpm ERR! 404 You should bug the author to publish it\nnpm ERR! 404 \nnpm ERR! 404 Note that you can also install from a\nnpm ERR! 404 tarball, folder, or http url, or git url.\n\nnpm ERR! System Linux 2.6.32-431.el6.x86_64\nnpm ERR! command \"/usr/bin/node\" \"/usr/bin/npm\" \"install\" \"--global\" \"nodejs_global_packages\"\nnpm ERR! cwd /home/vagrant\nnpm ERR! node -v v0.10.36\nnpm ERR! npm -v 1.4.28\nnpm ERR! code E404\nnpm ERR! \nnpm ERR! Additional logging details can be found in:\nnpm ERR!     /home/vagrant/npm-debug.log\nnpm ERR! not ok code 0", "rc": 1, "stderr": "npm ERR! 404 Not Found\nnpm ERR! 404 \nnpm ERR! 404 'nodejs_global_packages' is not in the npm registry.\nnpm ERR! 404 You should bug the author to publish it\nnpm ERR! 404 \nnpm ERR! 404 Note that you can also install from a\nnpm ERR! 404 tarball, folder, or http url, or git url.\n\nnpm ERR! System Linux 2.6.32-431.el6.x86_64\nnpm ERR! command \"/usr/bin/node\" \"/usr/bin/npm\" \"install\" \"--global\" \"nodejs_global_packages\"\nnpm ERR! cwd /home/vagrant\nnpm ERR! node -v v0.10.36\nnpm ERR! npm -v 1.4.28\nnpm ERR! code E404\nnpm ERR! \nnpm ERR! Additional logging details can be found in:\nnpm ERR!     /home/vagrant/npm-debug.log\nnpm ERR! not ok code 0\n", "stdout": "", "stdout_lines": []}

Wrapping it in a template expression as [the docs recommend](https://docs.ansible.com/ansible/playbooks_loops.html#standard-loops) fixes the issue