### PR TITLE
Don't compile as root

### DIFF
--- a/tasks/install_from_source.yml
+++ b/tasks/install_from_source.yml
@@ -22,8 +22,11 @@
   command: tar -xvzf {{nodejs_file_name}} chdir={{nodejs_tmp_dir}}
   when: wanted_version_installed.rc == 1
 
-- name: Compile and install nodejs {{nodejs_version_tag}}
-  shell: ./configure --prefix={{nodejs_path}} && make && make install chdir={{nodejs_tmp_dir}}{{nodejs_file_tag}}
-  sudo: true
+- name: Compile nodejs {{nodejs_version_tag}}
+  shell: ./configure --prefix={{nodejs_path}} && make
   when: wanted_version_installed.rc == 1
 
+- name: Install nodejs {{nodejs_version_tag}}
+  shell: make install chdir={{nodejs_tmp_dir}}{{nodejs_file_tag}}
+  sudo: true
+  when: wanted_version_installed.rc == 1

--- a/tasks/install_from_source.yml
+++ b/tasks/install_from_source.yml
@@ -23,7 +23,7 @@
   when: wanted_version_installed.rc == 1
 
 - name: Compile nodejs {{nodejs_version_tag}}
-  shell: ./configure --prefix={{nodejs_path}} && make
+  shell: ./configure --prefix={{nodejs_path}} && make chdir={{nodejs_tmp_dir}}{{nodejs_file_tag}}
   when: wanted_version_installed.rc == 1
 
 - name: Install nodejs {{nodejs_version_tag}}


### PR DESCRIPTION
@AnsibleShipyard/developers Please review. I just realized we are compiling as root, which is a bit of a no no as I understand it. This splits out the install task into a separate task that root is used for.